### PR TITLE
Reject rescue-tagged images as VM boot images [WAL-8603]

### DIFF
--- a/src/waldur_openstack/serializers.py
+++ b/src/waldur_openstack/serializers.py
@@ -4294,7 +4294,13 @@ class OpenStackInstanceCreateSerializer(OpenStackInstanceSerializer):
     image = serializers.HyperlinkedRelatedField(
         view_name="openstack-image-detail",
         lookup_field="uuid",
-        queryset=models.Image.objects.all().select_related("settings"),
+        # Exclude rescue-tagged images: an image with hw_rescue_device or
+        # hw_rescue_bus is meant for Nova rescue mode and is typically an
+        # ISO that won't boot a usable system disk. The HyperlinkedRelatedField
+        # will report it as not-found if a client tries to pass one.
+        queryset=models.Image.objects.filter(
+            hw_rescue_device="", hw_rescue_bus=""
+        ).select_related("settings"),
         write_only=True,
         help_text=_("The OS image to use for the instance"),
     )

--- a/src/waldur_openstack/tests/test_instance.py
+++ b/src/waldur_openstack/tests/test_instance.py
@@ -174,6 +174,27 @@ class InstanceCreateTest(test.APITestCase):
         response = self.create_instance(self.get_valid_data())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
 
+    def test_rescue_tagged_image_cannot_be_used_as_boot_image(self):
+        # Either hw_rescue property is enough to mark an image as a rescue
+        # image (matches Image.is_rescue_image). Such images are typically
+        # ISO-only and won't boot a usable system disk.
+        for field in ("hw_rescue_device", "hw_rescue_bus"):
+            with self.subTest(field=field):
+                rescue_image = factories.ImageFactory(
+                    settings=self.openstack_settings,
+                    **{field: "cdrom"},
+                )
+                rescue_image.tenants.add(self.tenant)
+                response = self.create_instance(
+                    self.get_valid_data(
+                        image=factories.ImageFactory.get_url(rescue_image),
+                    )
+                )
+                self.assertEqual(
+                    response.status_code, status.HTTP_400_BAD_REQUEST, response.data
+                )
+                self.assertIn("image", response.data)
+
     def test_user_can_define_fixed_ips(self):
         post_data = self.get_valid_data()
         fixed_ips = [{"ip_address": "192.168.0.1", "subnet_id": self.subnet.backend_id}]


### PR DESCRIPTION
## Summary

- `OpenStackInstanceCreateSerializer.image` queryset previously matched `Image.objects.all()`, which let a client `POST` an instance with a rescue-tagged image (Glance `hw_rescue_device` / `hw_rescue_bus`) as the boot image. Such images are typically ISOs and would produce a broken VM via Nova.
- Narrow the queryset to exclude rescue-tagged images. The `HyperlinkedRelatedField` now returns a does-not-exist error if one is passed by hand.

Companion to the homeport MR that hides rescue images from the deploy wizard's boot-image picker (waldur-homeport!6821). This is defence-in-depth: even with the frontend filter in place, anyone scripting against the API or pasting a UUID directly is now also rejected.

## Test plan

- [x] `pytest src/waldur_openstack/tests/test_instance.py::InstanceCreateTest` — 44 passed (includes new `test_rescue_tagged_image_cannot_be_used_as_boot_image` and the existing 14 rescue tests)
- [ ] Manually `POST /api/marketplace-orders/` (or the OpenStack instance create endpoint) with a rescue-tagged image UUID and confirm 400 with an `image` validation error.
- [ ] Confirm a regular image still works.