### PR TITLE
Set explicit User-Agent on Placement client requests

### DIFF
--- a/src/waldur_openstack/session.py
+++ b/src/waldur_openstack/session.py
@@ -308,7 +308,7 @@ class PlacementClient:
         # Some clouds register Placement only on the internal interface, so
         # try public first and fall back. Re-raise as OpenStackBackendError on
         # full failure so callers can decide whether to abort or skip.
-        headers = {"OpenStack-API-Version": f"placement {self.MICROVERSION}"}
+        headers = {"OpenStack-API-Version": f"placement {self.MICROVERSION}", "User-Agent": "waldur"}
         last_error = None
         for interface in ("public", "internal"):
             try:


### PR DESCRIPTION
## Problem

The Placement client in `waldur_openstack/session.py` builds its requests through
a bare keystoneauth `Session` without setting an application name. As a result,
requests fall back to the default urllib3 User-Agent.

Some OpenStack deployments sit behind a WAF or reverse proxy that blocks requests
based on the User-Agent header. In our case, the Placement endpoint silently
dropped the TCP connection (`RemoteDisconnected: Remote end closed connection
without response`) for any request carrying the default `python-urllib3/*` User-Agent,
while identical requests with a conventional User-Agent were served normally.

This breaks `pull_service_settings_quotas()` → `_collect_placement_data()` with a
`ConnectFailure`, moving the ServiceSettings into `ERRED`. Notably, the Nova/Cinder/
Neutron pulls are unaffected because those go through openstacksdk clients, which
set their own User-Agent — only the hand-rolled Placement client hits the default.

## Reproduction

From within the worker container, against the affected endpoint:

| User-Agent | Result |
|---|---|
| `python-urllib3/2.7.0` | connection closed without response |
| *(empty)* | connection closed without response |
| `curl/8.14.1` | 401 (served normally) |
| `waldur` | 401 (served normally) |

The failure is independent of auth method (application credential vs. password),
project, or IP version — the only differentiator is the User-Agent header.

## Fix

Add an explicit `User-Agent` header to the Placement client's requests so it no
longer relies on the urllib3 default. This aligns the Placement client with the
behaviour of the SDK-based clients.

## Notes

The root cause on the affected cloud is an overly aggressive User-Agent filter,
which should be addressed operator-side. However, sending a meaningful User-Agent
is good practice regardless and makes the Placement client robust against such
filters, consistent with the other OpenStack clients in this module.