### PR TITLE
Preserve a fractional quantity when updating a limit period

### DIFF
--- a/src/waldur_mastermind/marketplace/billing_limit.py
+++ b/src/waldur_mastermind/marketplace/billing_limit.py
@@ -403,7 +403,15 @@ class LimitPeriodProcessor:
         )
         resource_limit_periods = invoice_item.details["resource_limit_periods"]
         old_period = resource_limit_periods.pop()
-        old_quantity = int(old_period["quantity"])
+        # int() truncates a fractional quantity to 0, so a limit change on a
+        # component that was previously set to e.g. 0.1 is billed as if the old
+        # limit had been nothing. Keep the value JSON-native rather than
+        # Decimal: it is written straight back into details["resource_limit_periods"]
+        # by serialize_resource_limit_period, and a Decimal is not JSON
+        # encodable. Whole numbers stay int so existing payloads are unchanged.
+        old_quantity = float(old_period["quantity"])
+        if old_quantity.is_integer():
+            old_quantity = int(old_quantity)
         old_start = parse_datetime(old_period["start"])
         today = timezone.now()
         new_quantity = convert_quantity(


### PR DESCRIPTION
## Problem

`_update_invoice_item` truncates the previous period's quantity:

```python
old_quantity = int(old_period["quantity"])
```

So a limit change on a component previously set to a fractional value — say 0.1 TiB — is billed as though the old limit had been nothing. The old sub-period is re-serialised with `quantity: 0`, and its prorated share of the billing period is lost from `invoice_item.quantity`.

Unlike the `set_limits` 500 fixed in 595327da, this one is silent: the request succeeds and the invoice is quietly wrong, which makes it the harder of the two to notice.

## Change

```python
old_quantity = float(old_period["quantity"])
if old_quantity.is_integer():
    old_quantity = int(old_quantity)
```

Kept JSON-native rather than coerced to `Decimal`, because the value goes straight back into `details["resource_limit_periods"]` via `serialize_resource_limit_period` and a `Decimal` is not JSON encodable. Whole numbers stay `int`, so existing payloads are byte-identical and integer-only deployments see no change at all.

## Relationship to 595327da

595327da (`Coerce fractional limits to Decimal in total-period billing [#349]`) fixed the `float - Decimal` `TypeError` on the TOTAL path — thank you, that came from https://github.com/waldur/waldur-mastermind/issues/91. This is its sibling on the monthly/quarterly/annual path, which that commit did not touch. Both are needed before a fractional limit is safe end to end.

For reference, the fix is on `develop` but not in `8.1.3-rc.8`, which still carries both this truncation and the pre-fix subtraction.

## Verified

Built on 8.1.2 with this change plus the coercion, and run in a test deployment. Changing a `storage_project` limit from 0.1 to 0.5 on a resource that already had invoice items produced the correct pair of items — `0.1 @ 420 = 42.00` and a delta of `0.4 @ 420 = 168.00`, netting 210.00 for 0.5 TiB — where before it raised, and with only the coercion the old period would have contributed 0.

Licensing: I agree to license this contribution under the MIT license.
