### PR TITLE
Accept fractional component limits on the ordering and limit-change paths

### DIFF
--- a/src/waldur_mastermind/marketplace/serializers.py
+++ b/src/waldur_mastermind/marketplace/serializers.py
@@ -5530,6 +5530,20 @@ def validate_prepaid_duration_against_component(
             )
 
 
+class LimitValueField(serializers.FloatField):
+    """A component limit, which may be fractional.
+
+    Order.limits and Resource.limits are JSONFields written with the stdlib
+    encoder, so the value has to stay JSON-native — a Decimal raises at save
+    time. Whole numbers are returned as int so that a limit of 5 keeps
+    serialising as 5 rather than 5.0 and existing payloads are unchanged.
+    """
+
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        return int(value) if float(value).is_integer() else value
+
+
 class BaseOrderSerializer(BaseItemSerializer):
     class Meta(BaseItemSerializer.Meta):
         model = models.Order
@@ -5591,7 +5605,7 @@ class BaseOrderSerializer(BaseItemSerializer):
         read_only=True, source="resource.backend_type", allow_null=True
     )
     state = serializers.SerializerMethodField()
-    limits = serializers.DictField(child=serializers.IntegerField(), required=False)
+    limits = serializers.DictField(child=LimitValueField(), required=False)
     accepting_terms_of_service = serializers.BooleanField(
         required=False, write_only=True
     )
@@ -7522,7 +7536,7 @@ class ResourceRenewSerializer(serializers.Serializer):
         help_text=_("Number of months to extend the subscription by."),
     )
     limits = serializers.DictField(
-        child=serializers.IntegerField(min_value=0),
+        child=LimitValueField(min_value=0),
         required=False,
         help_text=_("Optional new limits for the resource. Supports upgrades only."),
     )
@@ -7562,7 +7576,7 @@ class RenewalEstimateRequestSerializer(serializers.Serializer):
         min_value=1, max_value=MAX_RENEWAL_MONTHS
     )
     limits = serializers.DictField(
-        child=serializers.IntegerField(min_value=0), required=False
+        child=LimitValueField(min_value=0), required=False
     )
 
     def validate(self, attrs):
@@ -7732,7 +7746,7 @@ class ResourceUpdateLimitsSerializer(serializers.ModelSerializer):
         fields = ("limits", "request_comment", "attachment")
 
     limits = serializers.DictField(
-        child=serializers.IntegerField(min_value=0), required=True
+        child=LimitValueField(min_value=0), required=True
     )
     attachment = serializers.FileField(
         required=False,
@@ -8078,14 +8092,14 @@ class ResourceLimitChangeRequestSerializer(serializers.HyperlinkedModelSerialize
 class ResourceReallocateTargetSerializer(serializers.Serializer):
     resource_uuid = serializers.UUIDField(required=True)
     allocated_limits = serializers.DictField(
-        child=serializers.IntegerField(min_value=1),
+        child=LimitValueField(min_value=1),
         required=True,
     )
 
 
 class ResourceReallocateLimitsSerializer(serializers.Serializer):
     limits = serializers.DictField(
-        child=serializers.IntegerField(min_value=1),
+        child=LimitValueField(min_value=1),
         required=True,
     )
 


### PR DESCRIPTION
## Problem

Every component limit field is `DictField(child=IntegerField())`, so a fractional limit can only ever reach a resource through the provider `set_limits` action, whose serializer uses a plain `JSONField`. Ordering one, changing one from the UI, renewing with one, or reallocating one all return `"A valid integer is required"`.

That matters for storage components measured in TiB, where a sub-TiB allocation is legitimate: a free-tier quota of 0.1 TiB has no integer representation. Today it can be provisioned by an operator but never requested by a customer — and the asymmetry is also why the two billing bugs in this area went unnoticed for so long, since `set_limits` was the only door a fraction could come through.

## Change

`LimitValueField` widens the six limit fields:

| serializer | field |
|---|---|
| `BaseOrderSerializer` | `limits` |
| `ResourceRenewSerializer` | `limits` |
| `RenewalEstimateRequestSerializer` | `limits` |
| `ResourceUpdateLimitsSerializer` | `limits` |
| `ResourceReallocateTargetSerializer` | `allocated_limits` |
| `ResourceReallocateLimitsSerializer` | `limits` |

It keeps the stored shape: whole numbers come back as `int`, so a limit of 5 still serialises as 5 rather than 5.0 and existing payloads are byte-identical.

`FloatField` rather than `DecimalField` is deliberate — `Order.limits` and `Resource.limits` are JSONFields written with the stdlib encoder, and a `Decimal` raises at save time. The billing path coerces to `Decimal` at the point of arithmetic instead, which is what 595327da does.

`QuotasUpdateSerializer.quotas` is left alone; quotas are counts, not measures. Read-only report serializers are untouched.

## Verified

Against DRF: `0.1` and `"0.1"` become `0.1` (float); `2` and `2.0` become `2` (int); `"abc"` is rejected; `min_value=0` still rejects `-0.5`.

Built on 8.1.2 and run in a test deployment: an order carrying `storage_project: 0.1` reaches `done` and the resource stores `{"cpu": 2000, "storage_project": 0.1, "storage_scratch": 2}` — types `int`, `float`, `int`.

## Related

- Client half: https://github.com/waldur/waldur-homeport/pull/105. Without it the forms still parse every limit input with `parseInt`, so this widened API is unreachable from the UI. The two are only useful together.
- Billing correctness: #93 fixes a silent truncation on the same path, and 595327da already fixed the `TypeError` from https://github.com/waldur/waldur-mastermind/issues/91. Both should land before fractional limits are reachable by customers, or the wider API will produce wrong invoices rather than errors.

Licensing: I agree to license this contribution under the MIT license.
